### PR TITLE
feat: Parallelize merge-manifests job using matrix strategy

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,8 +80,11 @@ jobs:
     permissions:
       contents: read
       packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        distro: ${{ fromJSON(needs.prepare-matrix.outputs.distro) }}
     steps:
-      - uses: actions/checkout@v6
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
@@ -95,54 +98,49 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Create and push manifest lists
+      - name: Create and push manifest list
         env:
-          DISTRO_MATRIX: ${{ needs.prepare-matrix.outputs.distro }}
+          OS: ${{ matrix.distro.OS }}
+          OS_VER: ${{ matrix.distro.OS_VER }}
+          PLATFORMS: ${{ matrix.distro.PLATFORMS || 'linux/amd64' }}
+          GHCR_IMAGE: ghcr.io/${{ github.repository_owner }}/docker-ansible
+          DOCKERHUB_IMAGE: docker.io/${{ vars.DOCKERHUB_USERNAME }}/docker-ansible
         run: |
-          echo "$DISTRO_MATRIX" | jq -c '.[]' | while read -r distro; do
-            OS=$(echo "$distro" | jq -r '.OS')
-            OS_VER=$(echo "$distro" | jq -r '.OS_VER')
-            PLATFORMS=$(echo "$distro" | jq -r '.PLATFORMS // "linux/amd64"')
+          TAG="0.0.0-${OS}.${OS_VER}"
+          LATEST_TAG="latest-${OS}.${OS_VER}"
 
-            TAG="0.0.0-${OS}.${OS_VER}"
-            LATEST_TAG="latest-${OS}.${OS_VER}"
+          # Build the list of source images based on platforms
+          SOURCE_IMAGES=""
+          if [[ "$PLATFORMS" == *"linux/amd64"* ]]; then
+            SOURCE_IMAGES="${SOURCE_IMAGES} ${GHCR_IMAGE}:0.0.0-amd64-${OS}.${OS_VER}"
+          fi
+          if [[ "$PLATFORMS" == *"linux/arm64"* ]]; then
+            SOURCE_IMAGES="${SOURCE_IMAGES} ${GHCR_IMAGE}:0.0.0-arm64-${OS}.${OS_VER}"
+          fi
 
-            GHCR_IMAGE="ghcr.io/${{ github.repository_owner }}/docker-ansible"
-            DOCKERHUB_IMAGE="docker.io/${{ vars.DOCKERHUB_USERNAME }}/docker-ansible"
+          echo "Creating manifest for ${OS}.${OS_VER} from:${SOURCE_IMAGES}"
 
-            # Build the list of source images based on platforms
-            SOURCE_IMAGES=""
-            if [[ "$PLATFORMS" == *"linux/amd64"* ]]; then
-              SOURCE_IMAGES="${SOURCE_IMAGES} ${GHCR_IMAGE}:0.0.0-amd64-${OS}.${OS_VER}"
-            fi
-            if [[ "$PLATFORMS" == *"linux/arm64"* ]]; then
-              SOURCE_IMAGES="${SOURCE_IMAGES} ${GHCR_IMAGE}:0.0.0-arm64-${OS}.${OS_VER}"
-            fi
+          # Create manifest for GHCR (versioned tag)
+          docker buildx imagetools create \
+            -t "${GHCR_IMAGE}:${TAG}" \
+            ${SOURCE_IMAGES}
 
-            echo "Creating manifest for ${OS}.${OS_VER} from:${SOURCE_IMAGES}"
+          # Create manifest for GHCR (latest tag)
+          docker buildx imagetools create \
+            -t "${GHCR_IMAGE}:${LATEST_TAG}" \
+            ${SOURCE_IMAGES}
 
-            # Create manifest for GHCR (versioned tag)
-            docker buildx imagetools create \
-              -t "${GHCR_IMAGE}:${TAG}" \
-              ${SOURCE_IMAGES}
+          # Create manifest for Docker Hub (versioned tag)
+          docker buildx imagetools create \
+            -t "${DOCKERHUB_IMAGE}:${TAG}" \
+            ${SOURCE_IMAGES}
 
-            # Create manifest for GHCR (latest tag)
-            docker buildx imagetools create \
-              -t "${GHCR_IMAGE}:${LATEST_TAG}" \
-              ${SOURCE_IMAGES}
+          # Create manifest for Docker Hub (latest tag)
+          docker buildx imagetools create \
+            -t "${DOCKERHUB_IMAGE}:${LATEST_TAG}" \
+            ${SOURCE_IMAGES}
 
-            # Create manifest for Docker Hub (versioned tag)
-            docker buildx imagetools create \
-              -t "${DOCKERHUB_IMAGE}:${TAG}" \
-              ${SOURCE_IMAGES}
-
-            # Create manifest for Docker Hub (latest tag)
-            docker buildx imagetools create \
-              -t "${DOCKERHUB_IMAGE}:${LATEST_TAG}" \
-              ${SOURCE_IMAGES}
-
-            echo "Created manifests for ${OS}.${OS_VER}"
-          done
+          echo "Created manifests for ${OS}.${OS_VER}"
 
   scan-images:
     needs: [prepare-matrix, merge-manifests]


### PR DESCRIPTION
## Summary

- Convert `merge-manifests` from a single sequential job to parallel matrix jobs
- Each distro (17 total) now gets its own job for manifest merging
- Removed unnecessary `actions/checkout` step (not needed for imagetools)

## Before

```
merge-manifests (1 job, processes 17 distros sequentially)
```

## After

```
merge-manifests (17 parallel jobs, one per distro)
```

## Benefits

- **Faster execution** - All manifest merges run concurrently
- **Better visibility** - Each distro has its own job status
- **Fault isolation** - One distro failing doesn't block others

🤖 Generated with [Claude Code](https://claude.com/claude-code)