### PR TITLE
fix: set DEBIAN_FRONTEND=noninteractive for apt-based distros

### DIFF
--- a/src/docker_ansible/main.py
+++ b/src/docker_ansible/main.py
@@ -82,7 +82,8 @@ class DockerAnsible:
                             apk update
                             ;;
                         apt)
-                            apt-get update
+                            export DEBIAN_FRONTEND=noninteractive
+                            apt-get update -qq
                             ;;
                         dnf|yum)
                             # dnf/yum don't need explicit update
@@ -105,7 +106,7 @@ class DockerAnsible:
                             apk add --no-cache "$@"
                             ;;
                         apt)
-                            apt-get install -y "$@"
+                            DEBIAN_FRONTEND=noninteractive apt-get install -y -qq "$@"
                             ;;
                         dnf)
                             dnf install -y --nobest --skip-broken "$@"


### PR DESCRIPTION
Prevents interactive prompts (tzdata, keyboard config, etc.) during package installation on Debian, Ubuntu, and Kali builds.

Also adds -qq flag to reduce apt output noise.