### PR TITLE
feat: update platform matrix to latest versions per distro

### DIFF
--- a/platform-matrix-v1.json
+++ b/platform-matrix-v1.json
@@ -1,17 +1,12 @@
 [
   {
     "OS": "alpine",
-    "OS_VER": "3.20",
-    "PLATFORMS": "linux/amd64,linux/arm64"
-  },
-  {
-    "OS": "alpine",
-    "OS_VER": "3.21",
-    "PLATFORMS": "linux/amd64,linux/arm64"
-  },
-  {
-    "OS": "alpine",
     "OS_VER": "3.22",
+    "PLATFORMS": "linux/amd64,linux/arm64"
+  },
+  {
+    "OS": "alpine",
+    "OS_VER": "3.23",
     "PLATFORMS": "linux/amd64,linux/arm64"
   },
   {
@@ -31,17 +26,7 @@
   },
   {
     "OS": "debian",
-    "OS_VER": "bullseye",
-    "PLATFORMS": "linux/amd64,linux/arm64"
-  },
-  {
-    "OS": "debian",
     "OS_VER": "trixie",
-    "PLATFORMS": "linux/amd64,linux/arm64"
-  },
-  {
-    "OS": "fedora",
-    "OS_VER": "42",
     "PLATFORMS": "linux/amd64,linux/arm64"
   },
   {
@@ -64,6 +49,13 @@
   {
     "OS": "rockylinux",
     "OS_VER": "9",
+    "PLATFORMS": "linux/amd64,linux/arm64"
+  },
+  {
+    "OS": "rockylinux",
+    "OS_VER": "10",
+    "UPSTREAM_ORG": "rockylinux",
+    "UPSTREAM_OS": "rockylinux",
     "PLATFORMS": "linux/amd64,linux/arm64"
   },
   {


### PR DESCRIPTION
- Alpine: 3.22, 3.23, edge
- Debian: bookworm, trixie
- Fedora: 43, 44
- Rocky Linux: 9, 10
- Ubuntu: jammy, noble (LTS only)
- UBI, Arch, Kali: unchanged