### PR TITLE
fix: scan both amd64 and arm64 images on native runners

### DIFF
--- a/.github/workflows/dagger-ansible-test-role.yml
+++ b/.github/workflows/dagger-ansible-test-role.yml
@@ -128,7 +128,7 @@ jobs:
 
   scan-images:
     needs: [prepare-matrix, merge-manifests]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.RUNNER }}
     permissions:
       contents: read
       packages: read
@@ -136,14 +136,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: ${{ fromJSON(needs.prepare-matrix.outputs.distro) }}
+        include: ${{ fromJSON(needs.prepare-matrix.outputs.build-matrix) }}
     steps:
       - uses: actions/checkout@v6
 
       - name: Scan image for vulnerabilities
         uses: aquasecurity/trivy-action@0.33.1
         with:
-          image-ref: "ghcr.io/${{ github.repository }}:0.0.0-${{ matrix.distro.OS }}.${{ matrix.distro.OS_VER }}.${{ github.sha }}"
+          image-ref: "ghcr.io/${{ github.repository }}:0.0.0-${{ matrix.ARCH }}-${{ matrix.OS }}.${{ matrix.OS_VER }}.${{ github.sha }}"
           severity: 'CRITICAL,HIGH'
           format: sarif
           output: trivy-results.sarif
@@ -156,7 +156,7 @@ jobs:
         if: always()
         with:
           sarif_file: trivy-results.sarif
-          category: 'trivy-${{ matrix.distro.OS }}-${{ matrix.distro.OS_VER }}'
+          category: 'trivy-${{ matrix.ARCH }}-${{ matrix.OS }}-${{ matrix.OS_VER }}'
 
   publish-final:
     needs: [prepare-matrix, scan-images]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -144,7 +144,7 @@ jobs:
 
   scan-images:
     needs: [prepare-matrix, merge-manifests]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.RUNNER }}
     permissions:
       contents: read
       packages: read
@@ -152,13 +152,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: ${{ fromJSON(needs.prepare-matrix.outputs.distro) }}
+        include: ${{ fromJSON(needs.prepare-matrix.outputs.build-matrix) }}
     steps:
       - uses: actions/checkout@v6
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.33.1
         with:
-          image-ref: ghcr.io/${{ github.repository_owner }}/docker-ansible:0.0.0-${{ matrix.distro.OS }}.${{ matrix.distro.OS_VER }}
+          image-ref: ghcr.io/${{ github.repository_owner }}/docker-ansible:0.0.0-${{ matrix.ARCH }}-${{ matrix.OS }}.${{ matrix.OS_VER }}
           format: sarif
           output: trivy-results.sarif
           severity: 'CRITICAL,HIGH'
@@ -169,4 +169,4 @@ jobs:
         if: always()
         with:
           sarif_file: trivy-results.sarif
-          category: 'trivy-${{ matrix.distro.OS }}-${{ matrix.distro.OS_VER }}'
+          category: 'trivy-${{ matrix.ARCH }}-${{ matrix.OS }}-${{ matrix.OS_VER }}'


### PR DESCRIPTION
## Summary
- Changed scan-images job in both workflows to use the expanded build-matrix (per-arch) instead of distro matrix
- Each architecture is now scanned on its native runner rather than only scanning amd64

## Affected workflows
- `publish.yml` - docker-ansible base images
- `dagger-ansible-test-role.yml` - Ansible role test images

## Changes
- Uses `matrix.RUNNER` to run scans on native runners (ubuntu-latest for amd64, ubuntu-24.04-arm for arm64)
- Scans per-arch images (`0.0.0-{arch}-{os}.{os_ver}`) instead of merged manifests
- Updates SARIF category to include architecture

## Test plan
- [ ] Verify amd64 scans run on ubuntu-latest
- [ ] Verify arm64 scans run on ubuntu-24.04-arm
- [ ] Verify SARIF results upload correctly for both architectures

🤖 Generated with [Claude Code](https://claude.com/claude-code)