### PR TITLE
fix: force container sync to ensure tests actually run

### DIFF
--- a/src/docker_ansible/main.py
+++ b/src/docker_ansible/main.py
@@ -546,6 +546,11 @@ class DockerAnsible:
             if p
         ]
 
+        # Force execution of all containers to ensure tests actually run
+        # Without this, Dagger's lazy evaluation would skip the tests
+        # when not publishing
+        await asyncio.gather(*[c.sync() for c in containers])
+
         published_images = []
 
         # Only publish if all required parameters are provided


### PR DESCRIPTION
## Summary
- Add `.sync()` call to force container execution when not publishing
- Dagger's lazy evaluation was skipping tests when publishing parameters weren't provided
- Tests would silently pass without actually running

## Root Cause
Dagger uses lazy evaluation - containers aren't actually executed until their output is needed (e.g., for publishing). When `test_role` was called without publishing parameters, the containers were created but never executed, so tests appeared to pass but weren't actually run.

## Changes
- Added `await asyncio.gather(*[c.sync() for c in containers])` to force execution before returning

## Test plan
- [x] Verified tests now actually run and fail correctly when there are issues
- [x] Verified tests pass when role is correctly configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)