### PR TITLE
chore: bump GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: build image
-        uses: dagger/dagger-for-github@v8.4.0
+        uses: dagger/dagger-for-github@v8.4.1
         with:
           module: .
           call: >-

--- a/.github/workflows/dagger-ansible-test-role.yml
+++ b/.github/workflows/dagger-ansible-test-role.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: ansible-lint
-        uses: ansible/ansible-lint@v25
+        uses: ansible/ansible-lint@v26
 
   prepare-matrix:
     runs-on: ubuntu-latest
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Build and test role
-        uses: dagger/dagger-for-github@v8.4.0
+        uses: dagger/dagger-for-github@v8.4.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -87,14 +87,14 @@ jobs:
         distro: ${{ fromJSON(needs.prepare-matrix.outputs.distro) }}
     steps:
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Create and push manifest list
         env:
@@ -170,14 +170,14 @@ jobs:
         distro: ${{ fromJSON(needs.prepare-matrix.outputs.distro) }}
     steps:
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Publish final tags
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,7 +54,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: publish arch-specific image to ghcr.io
-        uses: dagger/dagger-for-github@v8.4.0
+        uses: dagger/dagger-for-github@v8.4.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -86,18 +86,18 @@ jobs:
         distro: ${{ fromJSON(needs.prepare-matrix.outputs.distro) }}
     steps:
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Create and push manifest list
         env:
           OS: ${{ matrix.distro.OS }}

--- a/.github/workflows/test-role-single.yml
+++ b/.github/workflows/test-role-single.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Test role (without publishing)
         if: ${{ inputs.publish != true }}
-        uses: dagger/dagger-for-github@v8.4.0
+        uses: dagger/dagger-for-github@v8.4.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -80,7 +80,7 @@ jobs:
 
       - name: Test role (with publishing)
         if: ${{ inputs.publish == true }}
-        uses: dagger/dagger-for-github@v8.4.0
+        uses: dagger/dagger-for-github@v8.4.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/test-role.yml
+++ b/.github/workflows/test-role.yml
@@ -18,7 +18,7 @@ jobs:
           path: ansible-k9s
 
       - name: Test the test-role function on Ubuntu AMD64
-        uses: dagger/dagger-for-github@v8.4.0
+        uses: dagger/dagger-for-github@v8.4.1
         with:
           module: .
           call: >-
@@ -43,7 +43,7 @@ jobs:
           path: ansible-k9s
 
       - name: Test the test-role function on Ubuntu ARM64
-        uses: dagger/dagger-for-github@v8.4.0
+        uses: dagger/dagger-for-github@v8.4.1
         with:
           module: .
           call: >-


### PR DESCRIPTION
## Summary
- Bump `dagger/dagger-for-github` from v8.4.0 to v8.4.1
- Bump `docker/login-action` from v3 to v4
- Bump `docker/setup-buildx-action` from v3 to v4
- Bump `ansible/ansible-lint` from v25 to v26

## Test plan
- [ ] Verify CI workflows pass on this PR
- [ ] Confirm image builds and publishes work after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)